### PR TITLE
Fix tests using ChromeDriver

### DIFF
--- a/cloudtrust-common/pom.xml
+++ b/cloudtrust-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cloudtrust</groupId>
         <artifactId>cloudtrust-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>cloudtrust-common</artifactId>

--- a/cloudtrust-test-tools/pom.xml
+++ b/cloudtrust-test-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cloudtrust</groupId>
         <artifactId>cloudtrust-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>cloudtrust-test-tools</artifactId>

--- a/kc-cloudtrust-module/kc-cloudtrust-common/pom.xml
+++ b/kc-cloudtrust-module/kc-cloudtrust-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cloudtrust</groupId>
         <artifactId>kc-cloudtrust-module</artifactId>
-        <version>20.0.0-SNAPSHOT</version>
+        <version>20.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>kc-cloudtrust-common</artifactId>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>io.cloudtrust</groupId>
             <artifactId>cloudtrust-test-tools</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>4.0.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kc-cloudtrust-module/pom.xml
+++ b/kc-cloudtrust-module/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.cloudtrust</groupId>
     <artifactId>kc-cloudtrust-module</artifactId>
-    <version>20.0.0-SNAPSHOT</version>
+    <version>20.0.1-SNAPSHOT</version>
     <description>Parent for keycloak modules</description>
     <packaging>pom</packaging>
 
@@ -79,12 +79,12 @@
             <dependency>
                 <groupId>io.cloudtrust</groupId>
                 <artifactId>cloudtrust-common</artifactId>
-                <version>4.0.0-SNAPSHOT</version>
+                <version>4.0.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.cloudtrust</groupId>
                 <artifactId>kc-cloudtrust-common</artifactId>
-                <version>20.0.0-SNAPSHOT</version>
+                <version>20.0.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>

--- a/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/pom.xml
+++ b/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.cloudtrust</groupId>
         <artifactId>kc-cloudtrust-testsuite</artifactId>
-        <version>20.0.0-SNAPSHOT</version>
+        <version>20.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>kc-cloudtrust-test-tools</artifactId>
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <compress.version>1.22</compress.version>
-        <webdrivermanager.version>5.3.2</webdrivermanager.version>
+        <webdrivermanager.version>5.6.1</webdrivermanager.version>
     </properties>
 
     <dependencies>

--- a/kc-cloudtrust-testsuite/pom.xml
+++ b/kc-cloudtrust-testsuite/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>io.cloudtrust</groupId>
         <artifactId>cloudtrust-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>kc-cloudtrust-testsuite</artifactId>
-    <version>20.0.0-SNAPSHOT</version>
+    <version>20.0.1-SNAPSHOT</version>
     <description>Parent for testing of keycloak modules</description>
     <packaging>pom</packaging>
 
@@ -144,7 +144,7 @@
             <dependency>
                 <groupId>io.cloudtrust</groupId>
                 <artifactId>kc-cloudtrust-test-tools</artifactId>
-                <version>20.0.0-SNAPSHOT</version>
+                <version>20.0.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.cloudtrust</groupId>
     <artifactId>cloudtrust-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <scm>
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>io.cloudtrust</groupId>
                 <artifactId>cloudtrust-common</artifactId>
-                <version>4.0.0-SNAPSHOT</version>
+                <version>4.0.1-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
The version of webdrivermanager we are using is not up-to-date enough to be able to work with Chrome version higher than 114.