### PR TITLE
[CLOUDTRUST-6797] Test framework enhancements

### DIFF
--- a/build.pipeline
+++ b/build.pipeline
@@ -2,6 +2,7 @@ javaBuildPipeline(
     'kc-cloudtrust-parent',
     [
         [name: 'cloudtrust-parent', path: '.'],
+        [name: 'cloudtrust-bom', path: './cloudtrust-bom'],
         [name: 'cloudtrust-test-tools', path: './cloudtrust-test-tools'],
         [name: 'cloudtrust-common', path: './cloudtrust-common'],
         [name: 'kc-cloudtrust-common', path: './kc-cloudtrust-module/kc-cloudtrust-common', pom: './kc-cloudtrust-module/pom.xml'],

--- a/cloudtrust-bom/pom.xml
+++ b/cloudtrust-bom/pom.xml
@@ -1,0 +1,81 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.cloudtrust</groupId>
+        <artifactId>cloudtrust-parent</artifactId>
+        <version>26.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cloudtrust-bom</artifactId>
+    <packaging>pom</packaging>
+    <name>cloudtrust-bom</name>
+    <description>BOM exposing Cloudtrust managed dependencies and third-party versions</description>
+
+    <properties>
+        <!-- Third-party versions exposed to BOM consumers -->
+        <keycloak.version>26.2.4</keycloak.version>
+        <java.version>21</java.version>
+        <jackson-core.version>2.18.2</jackson-core.version>
+        <jackson-databind.version>2.18.2</jackson-databind.version>
+        <systemlambda.version>1.2.1</systemlambda.version>
+        <junit.version>5.11.3</junit.version>
+        <junit.platform.version>1.11.3</junit.platform.version>
+        <hamcrest.version>1.3</hamcrest.version>
+        <jacoco.version>0.8.12</jacoco.version>
+        <spotbugs.version>4.8.6</spotbugs.version>
+        <fb-contrib.version>7.6.8</fb-contrib.version>
+        <findsecbugs.version>1.13.0</findsecbugs.version>
+        <owasp-check.version>11.1.1</owasp-check.version>
+
+        <flatbuffers.version>1.10.0</flatbuffers.version>
+        <apache-collections.version>4.4</apache-collections.version>
+        <libphonenumber.version>9.0.4</libphonenumber.version>
+        <mockito.version>5.14.2</mockito.version>
+        <version.pmd.plugin>3.14.0</version.pmd.plugin>
+        <version.jboss.maven.plugin>7.9.Final</version.jboss.maven.plugin>
+        <version.wildfly.maven.plugin>2.0.2.Final</version.wildfly.maven.plugin>
+        <version.frontend.maven.plugin>1.12.1</version.frontend.maven.plugin>
+
+        <arquillian-graphene.version>2.5.4</arquillian-graphene.version>
+        <undertow.version>1.0.0.Final</undertow.version>
+        <jackson.version>2.18.2</jackson.version>
+        <jbosslogging.version>3.4.1.Final</jbosslogging.version>
+        <slf4j.version>2.0.16</slf4j.version>
+        <greenmail.version>2.1.2</greenmail.version>
+        <selenium.version>4.25.0</selenium.version>
+        <webdrivermanager.version>6.1.0</webdrivermanager.version>
+        <underdow.servlet.version>2.3.18.Final</underdow.servlet.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.cloudtrust</groupId>
+                <artifactId>cloudtrust-common</artifactId>
+                <version>${cloudtrust.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.cloudtrust</groupId>
+                <artifactId>kc-cloudtrust-common</artifactId>
+                <version>${cloudtrust.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.cloudtrust</groupId>
+                <artifactId>cloudtrust-test-tools</artifactId>
+                <version>${cloudtrust.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.cloudtrust</groupId>
+                <artifactId>kc-cloudtrust-test-tools</artifactId>
+                <version>${cloudtrust.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/cloudtrust-common/pom.xml
+++ b/cloudtrust-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cloudtrust</groupId>
         <artifactId>cloudtrust-parent</artifactId>
-        <version>26.0.10-SNAPSHOT</version>
+        <version>26.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cloudtrust-common</artifactId>

--- a/cloudtrust-test-tools/pom.xml
+++ b/cloudtrust-test-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cloudtrust</groupId>
         <artifactId>cloudtrust-parent</artifactId>
-        <version>26.0.10-SNAPSHOT</version>
+        <version>26.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cloudtrust-test-tools</artifactId>

--- a/kc-cloudtrust-module/kc-cloudtrust-common/pom.xml
+++ b/kc-cloudtrust-module/kc-cloudtrust-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cloudtrust</groupId>
         <artifactId>kc-cloudtrust-module</artifactId>
-        <version>26.0.10-SNAPSHOT</version>
+        <version>26.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kc-cloudtrust-common</artifactId>

--- a/kc-cloudtrust-module/pom.xml
+++ b/kc-cloudtrust-module/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.cloudtrust</groupId>
     <artifactId>kc-cloudtrust-module</artifactId>
-    <version>26.0.10-SNAPSHOT</version>
+    <version>26.1.0-SNAPSHOT</version>
     <description>Parent for keycloak modules</description>
     <packaging>pom</packaging>
 
@@ -12,6 +12,7 @@
     </modules>
 
     <properties>
+        <cloudtrust.version>26.1.0-SNAPSHOT</cloudtrust.version>
         <keycloak.version>26.2.4</keycloak.version>
         <flatbuffers.version>1.10.0</flatbuffers.version>
         <apache-collections.version>4.4</apache-collections.version>
@@ -72,12 +73,12 @@
             <dependency>
                 <groupId>io.cloudtrust</groupId>
                 <artifactId>cloudtrust-common</artifactId>
-                <version>${project.version}</version>
+                <version>${cloudtrust.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.cloudtrust</groupId>
                 <artifactId>kc-cloudtrust-common</artifactId>
-                <version>${project.version}</version>
+                <version>${cloudtrust.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>

--- a/kc-cloudtrust-testsuite/kc-cloudtrust-db-access/pom.xml
+++ b/kc-cloudtrust-testsuite/kc-cloudtrust-db-access/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.cloudtrust</groupId>
         <artifactId>kc-cloudtrust-testsuite</artifactId>
-        <version>26.0.10-SNAPSHOT</version>
+        <version>26.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kc-cloudtrust-db-access</artifactId>

--- a/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/pom.xml
+++ b/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.cloudtrust</groupId>
         <artifactId>kc-cloudtrust-testsuite</artifactId>
-        <version>26.0.10-SNAPSHOT</version>
+        <version>26.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kc-cloudtrust-test-tools</artifactId>
@@ -21,6 +21,10 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.cloudtrust</groupId>
+            <artifactId>cloudtrust-common</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>

--- a/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/src/main/java/io/cloudtrust/keycloak/test/KeycloakClientProvider.java
+++ b/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/src/main/java/io/cloudtrust/keycloak/test/KeycloakClientProvider.java
@@ -19,6 +19,7 @@ import org.keycloak.representations.idm.RealmEventsConfigRepresentation;
  *
  * @author fpe
  */
+@Deprecated
 public class KeycloakClientProvider {
     private static final Logger LOG = Logger.getLogger(KeycloakClientProvider.class);
 

--- a/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/src/main/java/io/cloudtrust/keycloak/test/ctpages/AbstractCtPage.java
+++ b/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/src/main/java/io/cloudtrust/keycloak/test/ctpages/AbstractCtPage.java
@@ -61,8 +61,14 @@ public abstract class AbstractCtPage extends AbstractPage {
         Assertions.assertTrue(isCurrent(), "Expected " + name + " but was " + driver.getTitle() + " (" + driver.getCurrentUrl() + ")");
     }
 
+    /**
+     * Deprecated method... Use AbstractPage::isActivePage instead
+     * @return true if the current page is the expected one
+     */
+    @Deprecated
     public boolean isCurrent() {
-        return false;
+        var currentPageId = getCurrentPageId();
+        return currentPageId!=null && currentPageId.equals(getExpectedPageId());
     }
 
     public boolean isNotCurrent() {
@@ -75,6 +81,10 @@ public abstract class AbstractCtPage extends AbstractPage {
 
     public void open() {
         throw new CloudtrustRuntimeException("open() not implemented");
+    }
+
+    public void open(ManagedRealm realm) {
+        this.driver.navigate().to(getLoginFormUrl(realm));
     }
 
     /**
@@ -216,6 +226,10 @@ public abstract class AbstractCtPage extends AbstractPage {
             input.sendKeys("1");
             input.sendKeys(Keys.BACK_SPACE);
         }
+    }
+
+    public void refresh() {
+        driver.navigate().refresh();
     }
 
     public String getCurrentUrl() {

--- a/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/src/main/java/io/cloudtrust/keycloak/test/ctpages/LoginPage.java
+++ b/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/src/main/java/io/cloudtrust/keycloak/test/ctpages/LoginPage.java
@@ -2,6 +2,7 @@ package io.cloudtrust.keycloak.test.ctpages;
 
 import org.junit.jupiter.api.Assertions;
 import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.ManagedUser;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
@@ -64,6 +65,10 @@ public class LoginPage extends AbstractCtPage {
     @Override
     public String getExpectedPageId() {
         return null;
+    }
+
+    public void login(ManagedUser user) {
+        login(user.getUsername(), user.getPassword());
     }
 
     public void login(String username, String password) {
@@ -142,8 +147,11 @@ public class LoginPage extends AbstractCtPage {
 
     @Override
     public boolean isCurrent() {
-        String realm = "test";
-        return isCurrent(realm);
+        return isCurrent("test");
+    }
+
+    public boolean isCurrent(ManagedRealm realm) {
+        return isCurrent(realm.getName());
     }
 
     public boolean isCurrent(String realm) {
@@ -188,12 +196,9 @@ public class LoginPage extends AbstractCtPage {
         return rememberMe.isSelected();
     }
 
+    @Override
     public void open(ManagedRealm realm) {
-        openLoginForm(realm);
+        super.open(realm);
         assertCurrent();
-    }
-
-    private void openLoginForm(ManagedRealm realm) {
-        driver.navigate().to(getLoginFormUrl(realm));
     }
 }

--- a/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/src/main/java/io/cloudtrust/keycloak/test/ctpages/LoginPasswordResetPage.java
+++ b/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/src/main/java/io/cloudtrust/keycloak/test/ctpages/LoginPasswordResetPage.java
@@ -49,7 +49,7 @@ public class LoginPasswordResetPage extends AbstractCtPage {
     }
 
     @Override
-    public boolean isCurrent() {
+    public boolean isActivePage() {
         return getPageTitle(driver).equals("Forgot Your Password?");
     }
 

--- a/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/src/main/java/io/cloudtrust/keycloak/test/events/EventsManager.java
+++ b/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/src/main/java/io/cloudtrust/keycloak/test/events/EventsManager.java
@@ -17,6 +17,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+@Deprecated
 public class EventsManager<T> {
     private static final Logger LOG = Logger.getLogger(EventsManager.class);
 

--- a/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/src/main/java/io/cloudtrust/keycloak/test/matchers/CtPageMatchers.java
+++ b/kc-cloudtrust-testsuite/kc-cloudtrust-test-tools/src/main/java/io/cloudtrust/keycloak/test/matchers/CtPageMatchers.java
@@ -20,14 +20,32 @@ public class CtPageMatchers extends AbstractMatchers<AbstractCtPage> {
         return item instanceof AbstractCtPage res ? res : null;
     }
 
+    /**
+     * Use isActivePage instead
+     * @return
+     */
+    @Deprecated
     public static BaseMatcher<AbstractCtPage> isCurrent() {
+        return isActivePage();
+    }
+
+    public static BaseMatcher<AbstractCtPage> isActivePage() {
         return new CtPageMatchers(
-                AbstractCtPage::isCurrent,
-                p -> String.format("Current page is %s", p.getClass().getName())
+                AbstractCtPage::isActivePage,
+                p -> String.format("Current page is %s (expected %s for class %s)", p.getCurrentPageId(), p.getExpectedPageId(), p.getClass().getName())
         );
     }
 
+    /**
+     * Use isNotActivePage instead
+     * @return
+     */
+    @Deprecated
     public static BaseMatcher<AbstractCtPage> isNotCurrent() {
+        return isNotActivePage();
+    }
+
+    public static BaseMatcher<AbstractCtPage> isNotActivePage() {
         return new CtPageMatchers(
                 p -> !p.isCurrent(),
                 p -> String.format("Current page is %s", p.getClass().getName()),

--- a/kc-cloudtrust-testsuite/pom.xml
+++ b/kc-cloudtrust-testsuite/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cloudtrust</groupId>
         <artifactId>kc-cloudtrust-module</artifactId>
-        <version>26.0.10-SNAPSHOT</version>
+        <version>26.1.0-SNAPSHOT</version>
         <relativePath>../kc-cloudtrust-module</relativePath>
     </parent>
 
@@ -44,10 +44,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>io.cloudtrust</groupId>
-            <artifactId>cloudtrust-common</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -140,18 +136,23 @@
         <dependencies>
             <dependency>
                 <groupId>io.cloudtrust</groupId>
+                <artifactId>cloudtrust-common</artifactId>
+                <version>${cloudtrust.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.cloudtrust</groupId>
                 <artifactId>cloudtrust-test-tools</artifactId>
-                <version>${project.version}</version>
+                <version>${cloudtrust.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.cloudtrust</groupId>
                 <artifactId>kc-cloudtrust-db-access</artifactId>
-                <version>${project.version}</version>
+                <version>${cloudtrust.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.cloudtrust</groupId>
                 <artifactId>kc-cloudtrust-test-tools</artifactId>
-                <version>${project.version}</version>
+                <version>${cloudtrust.version}</version>
             </dependency>
             <!-- env variables for unit tests -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.cloudtrust</groupId>
     <artifactId>cloudtrust-parent</artifactId>
-    <version>26.0.10-SNAPSHOT</version>
+    <version>26.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <scm>
@@ -14,6 +14,7 @@
     </scm>
 
     <modules>
+        <module>cloudtrust-bom</module>
         <module>cloudtrust-common</module>
         <module>cloudtrust-test-tools</module>
         <module>kc-cloudtrust-module</module>
@@ -21,6 +22,7 @@
     </modules>
 
     <properties>
+        <cloudtrust.version>26.1.0-SNAPSHOT</cloudtrust.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <keycloak.version>26.2.4</keycloak.version>
 
@@ -61,7 +63,7 @@
             <dependency>
                 <groupId>io.cloudtrust</groupId>
                 <artifactId>cloudtrust-common</artifactId>
-                <version>${project.version}</version>
+                <version>${cloudtrust.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Before releasing this change, we should update the pipeline with this command when increasing SNAPSHOT version number.
`mvn versions:set-property -Dproperty=cloudtrust.version -DnewVersion=26.1.1-SNAPSHOT -DgenerateBackupPoms=false`
None of our Keycloak modules should define this property. It should be defined only in cloudtrust-parent