### PR TITLE
[CLOUDTRUST-8809] Return null if we try to decrypt null

### DIFF
--- a/cloudtrust-common/src/main/java/io/cloudtrust/crypto/CryptoAesGcmUtil.java
+++ b/cloudtrust-common/src/main/java/io/cloudtrust/crypto/CryptoAesGcmUtil.java
@@ -186,6 +186,7 @@ public class CryptoAesGcmUtil {
     }
 
     public String decryptFromDatabaseStorageToString(String data) {
+        if (data == null) return null;
         return new String(decryptFromDatabaseStorage(data), StandardCharsets.UTF_8);
     }
 
@@ -196,6 +197,7 @@ public class CryptoAesGcmUtil {
      * @return decrypted data as a UTF-8 encoded String
      */
     public byte[] decryptFromDatabaseStorage(String data) {
+        if (data == null) return null;
         try {
             // parse json structure
             EncryptedData encData = new ObjectMapper().readValue(data, EncryptedData.class);

--- a/cloudtrust-common/src/test/java/io/cloudtrust/crypto/CryptoAesGcmUtilTest.java
+++ b/cloudtrust-common/src/test/java/io/cloudtrust/crypto/CryptoAesGcmUtilTest.java
@@ -79,6 +79,18 @@ class CryptoAesGcmUtilTest {
         assertThat(codec.decryptFromDatabaseStorage(encryptedString), equalTo("TEST_value".getBytes(StandardCharsets.UTF_8)));
     }
 
+    @Test
+    void testDecryptionOfNullValue() throws JsonProcessingException {
+        CryptoAesGcmUtil codec = CryptoAesGcmUtil.fromEnvironment();
+        assertThat(codec.decryptFromDatabaseStorage(null), nullValue());
+    }
+
+    @Test
+    void testDecryptionToStringOfNullValue() throws JsonProcessingException {
+        CryptoAesGcmUtil codec = CryptoAesGcmUtil.fromEnvironment();
+        assertThat(codec.decryptFromDatabaseStorageToString(null), nullValue());
+    }
+
     /**
      * test that the output fits by default in a VARCHAR(255) field in the DB
      *


### PR DESCRIPTION
This caused an issue where, during the update profile process, we tried to decrypt a user attribute with null value with another attribute that was changed. Keycloak calls getFirstAttribute on the null attribute, and we tried to decrypt it triggering an exception